### PR TITLE
github: run sel4bench build on pull request

### DIFF
--- a/.github/workflows/sel4bench-pr.yml
+++ b/.github/workflows/sel4bench-pr.yml
@@ -1,0 +1,112 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Build and run sel4bench on pull requests
+
+name: seL4Bench PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+    paths-ignore:
+      - '**.md'
+
+# downgrade permissions to read-only as you would have in a standard PR action
+permissions:
+  contents: read
+
+jobs:
+  code:
+    name: Freeze Code
+    runs-on: ubuntu-latest
+    outputs:
+      xml: ${{ steps.repo.outputs.xml }}
+    steps:
+    - id: repo
+      uses: seL4/ci-actions/repo-checkout@master
+      with:
+        manifest_repo: sel4bench-manifest
+        manifest: master.xml
+        sha: ${{ github.event.pull_request.head.sha }}
+
+  build:
+    name: Build
+    needs: code
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        march: [armv7a, armv8a, nehalem, rv64imac]
+    steps:
+    - name: Build
+      uses: seL4/ci-actions/sel4bench@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        march: ${{ matrix.march }}
+    - name: Upload images
+      uses: actions/upload-artifact@v3
+      with:
+        name: images-${{ matrix.march }}
+        path: '*-images.tar.gz'
+
+  hw-run:
+    name: HW Run
+    if: ${{ github.repository_owner == 'seL4' &&
+            (github.event_name == 'pull_request_target' &&
+               github.event.action != 'labeled' &&
+               contains(github.event.pull_request.labels.*.name, 'hw-test') ||
+             github.event_name == 'pull_request_target' &&
+               github.event.action == 'labeled' &&
+               github.event.label.name == 'hw-test') }}
+    runs-on: ubuntu-latest
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - sabre
+          - imx8mm_evk
+          - odroid_c2
+          - odroid_xu4
+          - am335x_boneblack
+          - tx1
+          - tx2
+          - hifive
+        include:
+          - platform: pc99
+            req: skylake
+          - platform: pc99
+            req: haswell3
+    # do run concurrently in the build matrix, but only one overall run per PR at a time
+    concurrency: sel4bench-hw-pr-${{ github.event.number }}-${{ strategy.job-index }}
+    steps:
+      - name: Get machine queue
+        uses: actions/checkout@v3
+        with:
+          repository: seL4/machine_queue
+          path: machine_queue
+          token: ${{ secrets.PRIV_REPO_TOKEN }}
+      - name: Get march
+        id: plat
+        uses: seL4/ci-actions/march-of-platform@master
+        with:
+          platform: ${{ matrix.platform }}
+      - name: Download image
+        uses: actions/download-artifact@v3
+        with:
+          name: images-${{ steps.plat.outputs.march }}
+      - name: Run
+        uses: seL4/ci-actions/sel4bench-hw@master
+        with:
+          platform: ${{ matrix.platform }}
+          req: ${{ matrix.req }}
+          index: $${{ strategy.job-index }}
+        env:
+          HW_SSH: ${{ secrets.HW_SSH }}
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          # funky expression below is to work around lack of ternary operator
+          name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}
+          path: '*.json'


### PR DESCRIPTION
Runs build on all PRs and enables hardware runs based on label `hw-test` as in sel4bench repo.

Fixes #10 