### PR TITLE
update OpenSBI to v1.2

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -8,9 +8,9 @@
   <remote name="opensbi" fetch="https://github.com/riscv"/>
   <remote name="seL4" fetch="."/>
   <remote name="seL4_projects" fetch="../SEL4PROJ/"/>
-  
+
   <default remote="seL4" revision="master"/>
-  
+
   <project name="musllibc.git" path="projects/musllibc" revision="3d6b939e8f05cb1d2a1a8c8166609bf2e652e975" upstream="sel4" dest-branch="sel4"/>
   <project name="nanopb" remote="nanopb" revision="1466e6f953835b191a7f5acf0c06c941d4cd33d9" upstream="master" dest-branch="refs/tags/0.4.3"/>
   <project name="opensbi" path="tools/opensbi" remote="opensbi" revision="a98258d0b537a295f517bbc8d813007336731fa9" upstream="refs/tags/v0.9" dest-branch="refs/tags/v0.9"/>

--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
 
   <project name="musllibc.git" path="projects/musllibc" revision="3d6b939e8f05cb1d2a1a8c8166609bf2e652e975" upstream="sel4" dest-branch="sel4"/>
   <project name="nanopb" remote="nanopb" revision="1466e6f953835b191a7f5acf0c06c941d4cd33d9" upstream="master" dest-branch="refs/tags/0.4.3"/>
-  <project name="opensbi" path="tools/opensbi" remote="opensbi" revision="a98258d0b537a295f517bbc8d813007336731fa9" upstream="refs/tags/v0.9" dest-branch="refs/tags/v0.9"/>
+  <project name="opensbi" path="tools/opensbi" remote="opensbi" revision="refs/tags/v0.9"/>
   <project name="projects_libs" path="projects/projects_libs" revision="524777b794762854214e6eff91bcafba261e0b42" upstream="master" dest-branch="master"/>
   <project name="seL4.git" path="kernel" revision="9b039f8e3729a466bfe151a9f24057f551d3ab4e" upstream="master" dest-branch="master"/>
   <project name="seL4_libs" path="projects/seL4_libs" revision="2ca525429e7b4f5abbc1fc694d3aeaff5eb6e7db" upstream="master" dest-branch="master"/>

--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
 
   <project name="musllibc.git" path="projects/musllibc" revision="3d6b939e8f05cb1d2a1a8c8166609bf2e652e975" upstream="sel4" dest-branch="sel4"/>
   <project name="nanopb" remote="nanopb" revision="1466e6f953835b191a7f5acf0c06c941d4cd33d9" upstream="master" dest-branch="refs/tags/0.4.3"/>
-  <project name="opensbi" path="tools/opensbi" remote="opensbi" revision="refs/tags/v0.9"/>
+  <project name="opensbi" path="tools/opensbi" remote="opensbi" revision="refs/tags/v1.0"/>
   <project name="projects_libs" path="projects/projects_libs" revision="524777b794762854214e6eff91bcafba261e0b42" upstream="master" dest-branch="master"/>
   <project name="seL4.git" path="kernel" revision="9b039f8e3729a466bfe151a9f24057f551d3ab4e" upstream="master" dest-branch="master"/>
   <project name="seL4_libs" path="projects/seL4_libs" revision="2ca525429e7b4f5abbc1fc694d3aeaff5eb6e7db" upstream="master" dest-branch="master"/>

--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
 
   <project name="musllibc.git" path="projects/musllibc" revision="3d6b939e8f05cb1d2a1a8c8166609bf2e652e975" upstream="sel4" dest-branch="sel4"/>
   <project name="nanopb" remote="nanopb" revision="1466e6f953835b191a7f5acf0c06c941d4cd33d9" upstream="master" dest-branch="refs/tags/0.4.3"/>
-  <project name="opensbi" path="tools/opensbi" remote="opensbi" revision="refs/tags/v1.1"/>
+  <project name="opensbi" path="tools/opensbi" remote="opensbi" revision="refs/tags/v1.2"/>
   <project name="projects_libs" path="projects/projects_libs" revision="524777b794762854214e6eff91bcafba261e0b42" upstream="master" dest-branch="master"/>
   <project name="seL4.git" path="kernel" revision="9b039f8e3729a466bfe151a9f24057f551d3ab4e" upstream="master" dest-branch="master"/>
   <project name="seL4_libs" path="projects/seL4_libs" revision="2ca525429e7b4f5abbc1fc694d3aeaff5eb6e7db" upstream="master" dest-branch="master"/>

--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
 
   <project name="musllibc.git" path="projects/musllibc" revision="3d6b939e8f05cb1d2a1a8c8166609bf2e652e975" upstream="sel4" dest-branch="sel4"/>
   <project name="nanopb" remote="nanopb" revision="1466e6f953835b191a7f5acf0c06c941d4cd33d9" upstream="master" dest-branch="refs/tags/0.4.3"/>
-  <project name="opensbi" path="tools/opensbi" remote="opensbi" revision="refs/tags/v1.0"/>
+  <project name="opensbi" path="tools/opensbi" remote="opensbi" revision="refs/tags/v1.1"/>
   <project name="projects_libs" path="projects/projects_libs" revision="524777b794762854214e6eff91bcafba261e0b42" upstream="master" dest-branch="master"/>
   <project name="seL4.git" path="kernel" revision="9b039f8e3729a466bfe151a9f24057f551d3ab4e" upstream="master" dest-branch="master"/>
   <project name="seL4_libs" path="projects/seL4_libs" revision="2ca525429e7b4f5abbc1fc694d3aeaff5eb6e7db" upstream="master" dest-branch="master"/>


### PR DESCRIPTION
v1.2 is the latest released version. Support for JH71110 was added afterwards unfortunately, trying to find out what the 1.3 release plans are.

Test with: axel-h/opensbi#1